### PR TITLE
[MVP-4] [FR-8] Adjust Gradebook view to fit new style

### DIFF
--- a/src/renderer/src/pages/Gradebook.tsx
+++ b/src/renderer/src/pages/Gradebook.tsx
@@ -208,111 +208,115 @@ function Gradebook(): React.JSX.Element {
     <div style={{ color: 'var(--ev-c-gray-1)' }}>
       <NavBar />
       <div style={{ paddingTop: '100px' }}>
-      {/* Page title */}
-      <h1>Assignment Gradebook</h1>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '0 24px' }}>
+          {/* Page title */}
+          <h1>Assignment Gradebook</h1>
 
-      {/* Assignment selection dropdown */}
-      <div style={{ margin: '16px 0' }}>
-        <label htmlFor="assignment-select">Select Assignment: </label>
+          {/* Assignment selection dropdown */}
+          <div style={{ margin: '16px 0' }}>
+            <label htmlFor="assignment-select">Select Assignment: </label>
 
-        {/* Dropdown that allows instructors to switch assignments (FR-8) */}
-        <select
-          id="assignment-select"
-          value={selectedAssignment}
-          onChange={(e) => setSelectedAssignment(e.target.value)}
-        >
-          <option>Assignment 1</option>
-          <option>Assignment 2</option>
-        </select>
-      </div>
+            {/* Dropdown that allows instructors to switch assignments (FR-8) */}
+            <select
+              id="assignment-select"
+              value={selectedAssignment}
+              onChange={(e) => setSelectedAssignment(e.target.value)}
+            >
+              <option>Assignment 1</option>
+              <option>Assignment 2</option>
+            </select>
+          </div>
 
-      {/* Class statistics summary */}
-      <div style={{ display: 'flex', gap: '24px', margin: '20px 0', fontWeight: 'bold' }}>
-        <div>
-          <span>Class Average: {averageScore === '--' ? '--' : `${averageScore}%`}</span>
-          <span style={{ marginLeft: '24px' }}>
-            Highest Score: {highestScore === '--' ? '--' : `${highestScore}%`}
-          </span>
-          <span style={{ marginLeft: '24px' }}>
-            Lowest Score: {lowestScore === '--' ? '--' : `${lowestScore}%`}
-          </span>
+          {/* Class statistics summary */}
+          <div style={{ display: 'flex', gap: '24px', margin: '20px 0', fontWeight: 'bold' }}>
+            <div>
+              <span>Class Average: {averageScore === '--' ? '--' : `${averageScore}%`}</span>
+              <span style={{ marginLeft: '24px' }}>
+                Highest Score: {highestScore === '--' ? '--' : `${highestScore}%`}
+              </span>
+              <span style={{ marginLeft: '24px' }}>
+                Lowest Score: {lowestScore === '--' ? '--' : `${lowestScore}%`}
+              </span>
+            </div>
+          </div>
+
+          {/* Student search input */}
+          <div style={{ margin: '16px 0' }}>
+            <label htmlFor="student-search">Search Student: </label>
+            <input
+              id="student-search"
+              type="text"
+              placeholder="Enter student name or ID"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              style={{ marginLeft: '8px', padding: '6px', width: '260px' }}
+            />
+          </div>
+
+          {/* Sort dropdown */}
+          <div style={{ margin: '16px 0' }}>
+            <label htmlFor="sort-select">Sort By: </label>
+            <select
+              id="sort-select"
+              value={sortOption}
+              onChange={(e) => setSortOption(e.target.value)}
+              style={{ marginLeft: '8px', padding: '6px' }}
+            >
+              <option value="name-asc">Student Name (A-Z)</option>
+              <option value="name-desc">Student Name (Z-A)</option>
+              <option value="score-asc">Highest Score (Low to High)</option>
+              <option value="score-desc">Highest Score (High to Low)</option>
+            </select>
+          </div>
+
+          {/* Table displaying students and their highest scores */}
+          <div style={{ overflowX: 'auto', marginBottom: '16px' }}>
+            <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+              {/* Table header */}
+              <thead>
+                <tr>
+                  <th style={cellStyle}>Student ID</th>
+                  <th style={cellStyle}>Student Name</th>
+                  <th style={cellStyle}>Highest Score</th>
+                  <th style={cellStyle}>Submission Count</th>
+                  <th style={cellStyle}>Last Submission Time</th>
+                  <th style={cellStyle}>Status</th>
+                </tr>
+              </thead>
+
+              {/* Table body generated dynamically from student data */}
+              <tbody>
+                {sortedStudents.map((student) => (
+                  <tr key={student.id}>
+                    <td style={cellStyle}>{student.id}</td>
+                    <td style={cellStyle}>{student.name}</td>
+                    <td style={cellStyle}>{student.score}</td>
+                    <td style={cellStyle}>{student.submissions}</td>
+                    <td style={cellStyle}>{student.lastSubmitted}</td>
+                    <td style={cellStyle}>{student.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Export CSV Button at the bottom-right corner of the table */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '8px' }}>
+            <button
+              onClick={handleExportCSV}
+              style={{
+                fontSize: '12px', // smaller text
+                padding: '4px 8px', // smaller button
+                opacity: 0.8, // slightly subtle
+                cursor: 'pointer'
+              }}
+            >
+              Export CSV
+            </button>
+          </div>
         </div>
       </div>
-
-      {/* Student search input */}
-      <div style={{ margin: '16px 0' }}>
-        <label htmlFor="student-search">Search Student: </label>
-        <input
-          id="student-search"
-          type="text"
-          placeholder="Enter student name or ID"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          style={{ marginLeft: '8px', padding: '6px', width: '260px' }}
-        />
-      </div>
-
-      {/* Sort dropdown */}
-      <div style={{ margin: '16px 0' }}>
-        <label htmlFor="sort-select">Sort By: </label>
-        <select
-          id="sort-select"
-          value={sortOption}
-          onChange={(e) => setSortOption(e.target.value)}
-          style={{ marginLeft: '8px', padding: '6px' }}
-        >
-          <option value="name-asc">Student Name (A-Z)</option>
-          <option value="name-desc">Student Name (Z-A)</option>
-          <option value="score-asc">Highest Score (Low to High)</option>
-          <option value="score-desc">Highest Score (High to Low)</option>
-        </select>
-      </div>
-
-      {/* Table displaying students and their highest scores */}
-      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
-        {/* Table header */}
-        <thead>
-          <tr>
-            <th style={cellStyle}>Student ID</th>
-            <th style={cellStyle}>Student Name</th>
-            <th style={cellStyle}>Highest Score</th>
-            <th style={cellStyle}>Submission Count</th>
-            <th style={cellStyle}>Last Submission Time</th>
-            <th style={cellStyle}>Status</th>
-          </tr>
-        </thead>
-
-        {/* Table body generated dynamically from student data */}
-        <tbody>
-          {sortedStudents.map((student) => (
-            <tr key={student.id}>
-              <td style={cellStyle}>{student.id}</td>
-              <td style={cellStyle}>{student.name}</td>
-              <td style={cellStyle}>{student.score}</td>
-              <td style={cellStyle}>{student.submissions}</td>
-              <td style={cellStyle}>{student.lastSubmitted}</td>
-              <td style={cellStyle}>{student.status}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      {/* Export CSV Button at the bottom-right corner of the table */}
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '8px' }}>
-        <button
-          onClick={handleExportCSV}
-          style={{
-            fontSize: '12px', // smaller text
-            padding: '4px 8px', // smaller button
-            opacity: 0.8, // slightly subtle
-            cursor: 'pointer'
-          }}
-        >
-          Export CSV
-        </button>
-      </div>
       <Footer />
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
**Addresses the Issue:** <[#26](https://github.com/UNLV-CS472-672/2026-S-GROUP3-BatchGrade/issues/26)>

### **PR Type:**
- [ ] Feature/functional requirement
- [ ] Bug fix
- [x] Code quality improvement
- [ ] Test-only
- [ ] CI/config
- [ ] Documentation

### **Requirement Description:**

Updated the Gradebook page layout to improve visual structure and usability. 
A centered content container with a fixed max width was added to prevent the interface from stretching across the entire window. Additionally, horizontal overflow handling was applied to the table to ensure it remains viewable within the page boundaries.

These changes were made to improve readability, maintain consistent UI alignment with other pages, and prevent layout issues caused by wide screen sizes.

### **Structural Design Changes:**

Modified the layout structure of the Gradebook page by introducing a nested container that constrains content width and centers it within the application window. The Footer component was also repositioned outside of the centered container to align with the global layout structure used by the NavBar.

### **Behavioral Changes:**

No functional behavior of the Gradebook features was changed. 
The updates only affect the visual presentation of the page, ensuring content is properly aligned and the table does not overflow horizontally on larger screens.

### **Diagrams:**

No changes to the existing diagrams.

### **CI Status:**

CI pipeline is green

### **Tests Added/Updated:**

Manually tested. Here's the before and after fixing the codes:

_**Before**_
<img width="2048" height="1143" alt="BeforeNavBar" src="https://github.com/user-attachments/assets/e279f6ff-4f35-41e2-8251-acd19e6cbae8" />

**_After_**
<img width="2048" height="1143" alt="AfterNavBar" src="https://github.com/user-attachments/assets/eb415375-639e-485e-b14c-5b9f734278f8" />
